### PR TITLE
chore: add some missing metadata to the cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 name = "srp6"
 version = "1.0.0-beta.1"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
+repository = "https://github.com/sassman/srp6-rs"
+categories = ["Cryptography"]
+keywords = [
+    "srp",
+    "secure remote password",
+    "authentication",
+    "key exchange",
+    "protocols",
+]
 edition = "2018"
 description = "A safe implementation of the secure remote password authentication and key-exchange protocol - SRP version 6 and 6a"
 license = "MIT"

--- a/src/big_number.rs
+++ b/src/big_number.rs
@@ -99,7 +99,7 @@ impl BigNumber {
     }
 
     pub fn num_bytes(&self) -> usize {
-        (self.0.bits() as usize + 7) / 8
+        self.0.bits().div_ceil(8) as usize
     }
 
     /// returns the byte vec in little endian byte order


### PR DESCRIPTION
Signed-off-by: Sven Kanoldt <sven+oss@d34dl0ck.me>
