### PR TITLE
fix: replace invalid keyword "key exchange" with "key-exchange"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["Cryptography"]
 keywords = [
     "srp",
     "authentication",
-    "key exchange",
+    "key-exchange",
     "protocols",
 ]
 edition = "2018"


### PR DESCRIPTION
## Summary
- crates.io rejected the v1.0.0-beta.2 publish: `"key exchange" is an invalid keyword` (spaces are not allowed).
- Replace the keyword with a hyphenated `key-exchange` so the metadata validates and publish succeeds.
- The bad `v1.0.0-beta.2` tag has been deleted so the release workflow can recreate it from a green main.

Failing run: https://github.com/sassman/srp6-rs/actions/runs/24612510327/job/71969349770

## Test plan
- [x] `cargo publish --dry-run --allow-dirty` succeeds locally
- [x] CI green on this PR
- [x] Re-tag `v1.0.0-beta.2` after merge and confirm the publish workflow succeeds