### PR TITLE
fix: use lowercase `cryptography` category slug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "srp6"
 version = "1.0.0-beta.2"
 authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
 repository = "https://github.com/sassman/srp6-rs"
-categories = ["Cryptography"]
+categories = ["cryptography"]
 keywords = [
     "srp",
     "authentication",


### PR DESCRIPTION
## Summary
- crates.io rejected the v1.0.0-beta.2 publish: `The following category slugs are not currently supported on crates.io: Cryptography`.
- Category slugs are case-sensitive and lowercase. Replace `Cryptography` with `cryptography` (verified against https://crates.io/api/v1/categories).
- The bad `v1.0.0-beta.2` tag has been removed again so the release workflow can recreate it from a green main after merge.

Failing run: https://github.com/sassman/srp6-rs/actions/runs/24614016533/job/71973230969

### Note
`authentication` is also a valid top-level slug and arguably fits SRP better than `cryptography`. Not adding it here to keep the fix minimal, but worth considering in a follow-up.

## Test plan
- [x] `cargo publish --dry-run --allow-dirty` succeeds locally
- [ ] CI green on this PR
- [ ] Re-tag `v1.0.0-beta.2` after merge and confirm publish workflow succeeds