### PR TITLE
ci(release): grant `contents: write` to the github-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
     name: post / github release
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Get version from tag


### PR DESCRIPTION
## Summary
- The github-release step of the v1.0.0-beta.2 release failed with `403 Resource not accessible by integration` because the default `GITHUB_TOKEN` is scoped to `contents: read`.
- Add a job-scoped `permissions: { contents: write }` on the `release` job so `softprops/action-gh-release` can create the release.
- `build` and `publish` stay read-only. `cargo publish` uses `CARGO_REGISTRY_TOKEN`, not `GITHUB_TOKEN`, so no change there.

Failing run: https://github.com/sassman/srp6-rs/actions/runs/24614589578/job/71974712686

## Note
The v1.0.0-beta.2 tag still points at the commit with the old workflow, and the crate is already on crates.io, so re-running the workflow would fail at `cargo publish` with "already uploaded". The release for this tag will be created manually via `gh release create`. Future tags will use the fixed workflow end-to-end.

## Test plan
- [ ] CI green on this PR
- [ ] Next tag cut (`v1.0.0` or next beta) runs the release job to completion